### PR TITLE
feat(please): set environment URL using new cli flag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.14', '1.15', '1.16', '1.17' ]
     steps:
 
-    - name: Set up Go 1.x
+    - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ${{ matrix.go }}
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/command/please.go
+++ b/command/please.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 const TaskName = "github-deploy"
@@ -26,6 +26,7 @@ func CmdPlease(c *cli.Context) (err error) {
 	branch := c.GlobalString("git-branch")
 	commitRef := c.GlobalBool("git-ref-commit")
 	origin := c.GlobalString("git-origin")
+	environmentURL := c.String("environment-url")
 
 	// Compose the Git originl URL in the case of GitHub Actions
 	if origin == "" && os.Getenv("GITHUB_SERVER_URL") != "" {
@@ -161,7 +162,9 @@ func CmdPlease(c *cli.Context) (err error) {
 
 	// Success!
 	out := strings.SplitN(stdout.String(), "\n", 2)
-	environmentURL := strings.TrimSpace(out[0])
+	if environmentURL == "" {
+		environmentURL = strings.TrimSpace(out[0])
+	}
 	err = updateStatus(StateSuccess, environmentURL)
 	return err
 }

--- a/commands.go
+++ b/commands.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/zimbatm/github-deploy/command"
-	"github.com/zimbatm/go-secretvalue"
-	"gopkg.in/urfave/cli.v1"
+	secretvalue "github.com/zimbatm/go-secretvalue"
+	cli "gopkg.in/urfave/cli.v1"
 	"gopkg.in/urfave/cli.v1/altsrc"
 )
 
@@ -64,6 +64,11 @@ var Commands = []cli.Command{
 				Name:  "environment",
 				Value: "production",
 				Usage: "Sets the target environment, ignored if pull-request is passed",
+			},
+			cli.StringFlag{
+				Name:  "environment-url",
+				Value: "",
+				Usage: "Optional url to access your environment",
 			},
 			cli.StringFlag{
 				Name:  "build-url",

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/zimbatm/github-deploy/gitsrc"
-	"gopkg.in/urfave/cli.v1"
-	"gopkg.in/urfave/cli.v1/altsrc"
+	cli "gopkg.in/urfave/cli.v1"
+	altsrc "gopkg.in/urfave/cli.v1/altsrc"
 )
 
 func main() {


### PR DESCRIPTION
Define the environment URL to access the deployment with new cli flag (`--environment-url`) instead of parsing deploy script stdout.
