### PR TITLE
feat(please): handle scripts arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ USAGE:
    github-deploy [global options] command [command options] [arguments...]
 
 VERSION:
-   0.4.0
+   0.5.0
 
 AUTHOR:
    zimbatm <zimbatm@zimbatm.com>

--- a/commands.go
+++ b/commands.go
@@ -51,7 +51,7 @@ var Commands = []cli.Command{
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "deploy-script",
-				Usage: "Script that deploys the given PR",
+				Usage: "DEPRECATED. Use a positional argument instead.",
 			},
 			cli.StringFlag{
 				Name:  "pr, pull-request",


### PR DESCRIPTION
Change the passing of the deploy script to use DJB-style argument
parsing and allowing an arbitrary number of arguments.

Replaces #5 