### PR TITLE
feat(cleanup): handle script arguments

### DIFF
--- a/command/cleanup.go
+++ b/command/cleanup.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/google/go-github/github"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 func CmdCleanup(c *cli.Context) (err error) {
 	owner, repo := githubSlug(c)
 	listScript := c.String("list-script")
-	undeployScript := c.String("undeploy-script")
 	ctx := context.Background()
 	gh := githubClient(ctx, c)
 
@@ -60,7 +60,10 @@ func CmdCleanup(c *cli.Context) (err error) {
 
 	for _, name := range toUndeploy {
 		log.Println("Undeploying", name)
-		err := exec.Command(undeployScript, name).Run()
+		cmd := exec.Command(c.Args().Get(0), c.Args()[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
 		if err != nil {
 			log.Println("undeploy error:", err)
 		}

--- a/commands.go
+++ b/commands.go
@@ -89,10 +89,6 @@ var Commands = []cli.Command{
 				Name:  "list-script",
 				Usage: "Script that lists the deployed PRs",
 			},
-			cli.StringFlag{
-				Name:  "undeploy-script",
-				Usage: "Script that deleted a deployment given a specific PR",
-			},
 		},
 	},
 }


### PR DESCRIPTION
Change the passing of the cleanup script to use DJB-style argument
parsing and allow an arbitrary number of arguments.