### PR TITLE
fix: list existing deployments in the same environment

### DIFF
--- a/command/please.go
+++ b/command/please.go
@@ -97,12 +97,13 @@ func CmdPlease(c *cli.Context) (err error) {
 
 	// First, declare the new deployment to GitHub
 
-	// Look for an existing deployment
+	// Look for an existing deployment in the same environment
 	owner, repo := githubSlug(c)
 
 	deployments, _, err := ghCli.Repositories.ListDeployments(ctx, owner, repo, &github.DeploymentsListOptions{
-		Ref:  ref,
-		Task: TaskName,
+		Ref:         ref,
+		Task:        TaskName,
+		Environment: environment,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
As one commit can be deployed in different environments, we have to take the environment into account
when listing existing deployments for a commit.

API: https://docs.github.com/en/rest/deployments/deployments#list-deployments