### PR TITLE
feat: propagate signals to launched subprocesses so that they can properly clean up resources

### DIFF
--- a/command/utils.go
+++ b/command/utils.go
@@ -3,6 +3,8 @@ package command
 import (
 	"context"
 	"log"
+	"os"
+	"os/exec"
 	"regexp"
 
 	"github.com/google/go-github/github"
@@ -60,4 +62,18 @@ func refString(str string) *string {
 
 func refStringList(l []string) *[]string {
 	return &l
+}
+
+func propagateSignalsTo(cmd *exec.Cmd, signalChannel chan os.Signal) {
+	for sig := range signalChannel {
+		if cmd.Process != nil {
+			err := cmd.Process.Signal(sig)
+			if err != nil {
+				log.Printf("error sending signal to child process (%d): %s\n", cmd.Process.Pid, err)
+			}
+		} else {
+			// TODO: is this always the right thing to do if we're not running a subprocess?
+			os.Exit(1)
+		}
+	}
 }


### PR DESCRIPTION
Please let me know if there is a better way to do this, I haven't written Go in a long time.

There also seems to be some bug, but I'm not sure where the issue is coming from. If the underlying process doesn't exit, for instance after receiving SIGHUP, and we sent another signal, then `cmd.Process.Pid` ends up decremented by one, and so we try to send the signal to the wrong process. I don't know if I'm holding something the wrong way here, or if this is a Go runtime bug. This is what I see when sending SIGHUP twice:
```
2024/11/18 15:36:12 deploy ref refs/heads/main
2024/11/18 15:36:12 origin XXXX
Installing signal handlers...
Done
Launched child, child pid: 218206
Caught OTHER signal!
Passing signal to child process
2024/11/18 15:36:40 error sending signal to child process (218205): os: process already finished
```
Which is really strange, because there is no process with PID 218205, and the actual spawned process has PID 218206.